### PR TITLE
Support for Password-Protected ZIP in streamFileFromZip - unzipFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/react-native-zip-stream.svg?style=flat-square)](https://www.npmjs.com/package/react-native-zip-stream)
 
-A React Native module for working with ZIP archives. This module allows you to list the contents of ZIP files, stream files from ZIP archives, create new ZIP files, and unzip files with progress tracking.
+A React Native module for working with ZIP archives. This module allows you to list the contents of ZIP files, stream files from ZIP archives, create new ZIP files. Now supports password-protected ZIPs.
 
 ## Table of Contents
 
@@ -13,7 +13,6 @@ A React Native module for working with ZIP archives. This module allows you to l
   - [Stream File from Zip](#stream-file-from-zip)
   - [Unzip File](#unzip-file)
   - [Create Zip File](#create-zip-file)
-  - [Unzip File with Progress](#unzip-file-with-progress)
 - [API Reference](#api-reference)
   - [listZipContents](#listzipcontents)
   - [streamFileFromZip](#streamfilefromzip)
@@ -74,11 +73,11 @@ Lists the contents of a ZIP file. This function returns an array of file names c
 
 ### Stream File from Zip
 
-Streams a specific file from a ZIP archive. You can retrieve the file data in one of three formats: `base64`, `arraybuffer`, or `string`.
+Streams a specific file from a ZIP archive. You can retrieve the file data in one of three formats: `base64`, `arraybuffer`, or `string`. Now supports password-protected ZIPs.
 
 ### Unzip File
 
-Extracts all the contents of a ZIP file to a specified destination directory.
+Extracts all the contents of a ZIP file to a specified destination directory. Now supports password-protected ZIPs.
 
 ### Create Zip File
 
@@ -100,30 +99,36 @@ Lists the contents of a ZIP file.
 
 ### streamFileFromZip
 
-Streams a specific file from the ZIP archive.
+Streams a specific file from the ZIP archive, with optional password support.
 
 #### Parameters
 
 - `zipFilePath`: `string` - The full path to the ZIP file.
 - `entryName`: `string` - The name of the file within the ZIP archive to extract.
 - `type`: `string` (optional, default: `base64`) - The format in which to return the file data. Can be `base64`, `arraybuffer`, or `string`.
+- `password`: `string` (optional) - The password for the ZIP file, if it is encrypted.
 
 #### Returns
 
 - `Promise<string | ArrayBuffer | Uint8Array>` - A promise that resolves to the file content in the specified format.
 
+---
+
 ### unzipFile
 
-Extracts all the contents of a ZIP file to a specified destination directory.
+Extracts all the contents of a password-protected ZIP file to a specified destination directory.
 
 #### Parameters
 
 - `zipFilePath`: `string` - The full path to the ZIP file.
 - `destinationPath`: `string` - The path where the contents of the ZIP file should be extracted.
+- `password`: `string` (optional) - The password for the ZIP file, if it is encrypted.
 
 #### Returns
 
 - `Promise<boolean>` - A promise that resolves to `true` if the operation is successful.
+
+---
 
 ### createZipFile
 
@@ -157,34 +162,38 @@ const exampleListZipContents = async () => {
 };
 ```
 
-### Stream File from Zip Example
+### Stream File from Password-Protected Zip Example
 
 ```typescript
 import { streamFileFromZip } from 'react-native-zip-stream';
 
 const zipFilePath = '/path/to/your/zipfile.zip';
 const entryName = 'fileInsideZip.txt';
+const password = 'yourPassword';
 
 const exampleStreamFile = async () => {
   try {
     const base64Data = await streamFileFromZip(
       zipFilePath,
       entryName,
-      'base64'
+      'base64',
+      password
     );
     console.log('Base64 Data:', base64Data);
 
     const arrayBufferData = await streamFileFromZip(
       zipFilePath,
       entryName,
-      'arraybuffer'
+      'arraybuffer',
+      password
     );
     console.log('ArrayBuffer Data:', new Uint8Array(arrayBufferData));
 
     const stringData = await streamFileFromZip(
       zipFilePath,
       entryName,
-      'string'
+      'string',
+      password
     );
     console.log('String Data:', stringData);
   } catch (error) {
@@ -193,17 +202,18 @@ const exampleStreamFile = async () => {
 };
 ```
 
-### Unzip File Example
+### Unzip Password-Protected File Example
 
 ```typescript
 import { unzipFile } from 'react-native-zip-stream';
 
 const zipFilePath = '/path/to/your/zipfile.zip';
 const destinationPath = '/path/to/extract/';
+const password = 'yourPassword';
 
 const exampleUnzipFile = async () => {
   try {
-    const success = await unzipFile(zipFilePath, destinationPath);
+    const success = await unzipFile(zipFilePath, destinationPath, password);
     console.log('Unzip successful:', success);
   } catch (error) {
     console.error('Error unzipping file:', error);

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Lists the contents of a ZIP file.
 #### Parameters
 
 - `zipFilePath`: `string` - The full path to the ZIP file.
+- `password`: `string` (optional) - The password for the ZIP file, if it is encrypted.
 
 #### Returns
 
@@ -138,6 +139,7 @@ Creates a new ZIP file from the contents of a specified directory.
 
 - `destinationPath`: `string` - The full path where the ZIP file should be created.
 - `sourcePath`: `string` - The path to the directory or file that should be zipped.
+- `password`: `string` (optional) - The password for the ZIP file, if it is encrypted.
 
 #### Returns
 
@@ -228,10 +230,11 @@ import { createZipFile } from 'react-native-zip-stream';
 
 const sourcePath = '/path/to/source/folder';
 const destinationPath = '/path/to/output.zip';
+const password = 'yourPassword';
 
 const exampleCreateZipFile = async () => {
   try {
-    const success = await createZipFile(destinationPath, sourcePath);
+    const success = await createZipFile(destinationPath, sourcePath, password);
     console.log('Zip creation successful:', success);
   } catch (error) {
     console.error('Error creating zip file:', error);

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,5 +95,6 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+  implementation 'net.lingala.zip4j:zip4j:2.9.0'
 }
 

--- a/android/src/main/java/com/zipstream/ZipStreamModule.kt
+++ b/android/src/main/java/com/zipstream/ZipStreamModule.kt
@@ -4,148 +4,133 @@ import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
-import java.io.*
-import java.nio.charset.StandardCharsets
-import android.util.Base64
-import java.util.zip.ZipEntry
-import java.util.zip.ZipFile
-import java.util.zip.ZipOutputStream
 import net.lingala.zip4j.ZipFile
 import net.lingala.zip4j.exception.ZipException
+import net.lingala.zip4j.model.FileHeader
+import net.lingala.zip4j.model.ZipParameters
+import net.lingala.zip4j.model.enums.EncryptionMethod
+import net.lingala.zip4j.model.enums.CompressionLevel
+import java.io.ByteArrayOutputStream
+import java.io.File
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableArray
 
 class ZipStreamModule(reactContext: ReactApplicationContext) :
-  ReactContextBaseJavaModule(reactContext) {
+    ReactContextBaseJavaModule(reactContext) {
 
-  override fun getName(): String {
-    return NAME
-  }
+    override fun getName(): String {
+        return "ZipStream"
+    }
 
-  @ReactMethod
-  fun listZipContents(zipFilePath: String, promise: Promise) {
+@ReactMethod
+fun listZipContents(zipFilePath: String, promise: Promise, password: String?) {
     try {
-      ZipFile(zipFilePath).use { zipFile ->
-        val entries = zipFile.entries()
+        val zipFile = ZipFile(zipFilePath)
+        if (zipFile.isEncrypted && password != null) {
+            zipFile.setPassword(password.toCharArray())
+        }
+
+        val fileHeaders = zipFile.fileHeaders
         val fileNames = ArrayList<String>()
 
-        while (entries.hasMoreElements()) {
-          val entry = entries.nextElement()
-          fileNames.add(entry.name)
+        for (fileHeader in fileHeaders) {
+            fileNames.add(fileHeader.fileName)
         }
 
-        promise.resolve(fileNames)
-      }
-    } catch (e: Exception) {
-      promise.reject("ERROR_LISTING_CONTENTS", "Failed to list contents of the ZIP file", e)
+        // Convert ArrayList<String> to WritableArray
+        val writableArray: WritableArray = Arguments.createArray()
+        for (fileName in fileNames) {
+            writableArray.pushString(fileName)
+        }
+
+        promise.resolve(writableArray)
+    } catch (e: ZipException) {
+        promise.reject("ERROR_LISTING_CONTENTS", "Failed to list contents of the ZIP file", e)
     }
-  }
-
-  @ReactMethod
-  fun streamFileFromZip(zipFilePath: String, entryName: String, type: String, password: String?, promise: Promise) {
-      try {
-          val zipFile = ZipFile(zipFilePath)
-
-          if (zipFile.isEncrypted && password != null) {
-              zipFile.setPassword(password.toCharArray())
-          }
-
-          val entry = zipFile.getFileHeader(entryName)
-
-          if (entry == null) {
-              promise.reject("ERROR_STREAMING_FILE", "File not found in ZIP")
-              return
-          }
-
-          val inputStream = zipFile.getInputStream(entry)
-          val byteArrayOutputStream = ByteArrayOutputStream()
-          val buffer = ByteArray(1024)
-          var length: Int
-
-          while (inputStream.read(buffer).also { length = it } != -1) {
-              byteArrayOutputStream.write(buffer, 0, length)
-          }
-
-          val fileContents = byteArrayOutputStream.toByteArray()
-
-          when (type) {
-              "base64" -> {
-                  val base64Data = Base64.encodeToString(fileContents, Base64.NO_WRAP)
-                  promise.resolve(base64Data)
-              }
-              "arraybuffer" -> promise.resolve(fileContents)
-              "string" -> {
-                  val stringData = String(fileContents, StandardCharsets.UTF_8)
-                  promise.resolve(stringData)
-              }
-              else -> promise.reject("ERROR_STREAMING_FILE", "Invalid type specified")
-          }
-
-          zipFile.close()
-      } catch (e: Exception) {
-          promise.reject("ERROR_STREAMING_FILE", "Failed to stream the file", e)
-      }
-  }
-
-
-  @ReactMethod
-  fun unzipFile(zipFilePath: String, destinationPath: String, password: String?, promise: Promise) {
-      try {
-          val zipFile = ZipFile(zipFilePath)
-
-          if (zipFile.isEncrypted && password != null) {
-              zipFile.setPassword(password.toCharArray())
-          }
-
-          zipFile.extractAll(destinationPath)
-          promise.resolve(true)
-      } catch (e: ZipException) {
-          promise.reject("ERROR_UNZIPPING_FILE", "Failed to unzip the file", e)
-      } catch (e: Exception) {
-          promise.reject("ERROR_UNZIPPING_FILE", "An error occurred", e)
-      }
-  }
-
-  @ReactMethod
-  fun createZipFile(destinationPath: String, sourcePath: String, promise: Promise) {
+}
+@ReactMethod
+fun streamFileFromZip(zipFilePath: String, entryName: String, password: String?, type: String, promise: Promise) {
     try {
-      FileOutputStream(destinationPath).use { fos ->
-        ZipOutputStream(fos).use { zos ->
-          val sourceFile = File(sourcePath)
-          zipDirectory(sourceFile, sourceFile.name, zos)
+        val zipFile = ZipFile(zipFilePath)
+        if (zipFile.isEncrypted && password != null) {
+            zipFile.setPassword(password.toCharArray())
         }
-      }
-      promise.resolve(true)
-    } catch (e: Exception) {
-      promise.reject("ERROR_CREATING_ZIP", "Failed to create ZIP file", e)
-    }
-  }
 
-  @Throws(IOException::class)
-  private fun zipDirectory(fileToZip: File, fileName: String, zos: ZipOutputStream) {
-    if (fileToZip.isHidden) {
-      return
-    }
-    if (fileToZip.isDirectory) {
-      val zipEntryName = if (fileName.endsWith("/")) fileName else "$fileName/"
-      zos.putNextEntry(ZipEntry(zipEntryName))
-      zos.closeEntry()
+        val fileHeader = zipFile.getFileHeader(entryName)
+        if (fileHeader == null) {
+            promise.reject("ERROR_STREAMING_FILE", "File not found in ZIP")
+            return
+        }
 
-      fileToZip.listFiles()?.forEach { childFile ->
-        zipDirectory(childFile, "$fileName/${childFile.name}", zos)
-      }
-    } else {
-      FileInputStream(fileToZip).use { fis ->
-        val zipEntry = ZipEntry(fileName)
-        zos.putNextEntry(zipEntry)
+        val inputStream = zipFile.getInputStream(fileHeader)
+        val byteArrayOutputStream = ByteArrayOutputStream()
+
         val buffer = ByteArray(4096)
         var length: Int
-        while (fis.read(buffer).also { length = it } >= 0) {
-          zos.write(buffer, 0, length)
+        while (inputStream.read(buffer).also { length = it } != -1) {
+            byteArrayOutputStream.write(buffer, 0, length)
         }
-      }
-    }
-  }
 
-  companion object {
-    const val NAME = "ZipStream"
-  }
+        val fileContents = byteArrayOutputStream.toByteArray()
+
+        when (type) {
+            "base64" -> {
+                val base64Data = android.util.Base64.encodeToString(fileContents, android.util.Base64.NO_WRAP)
+                promise.resolve(base64Data)
+            }
+            "arraybuffer" -> promise.resolve(fileContents)
+            "string" -> {
+                val stringData = String(fileContents, Charsets.UTF_8)
+                promise.resolve(stringData)
+            }
+            else -> promise.reject("ERROR_STREAMING_FILE", "Invalid type specified")
+        }
+    } catch (e: Exception) {
+        promise.reject("ERROR_STREAMING_FILE", "Failed to stream the file", e)
+    }
+}
+
+
+    @ReactMethod
+    fun unzipFile(zipFilePath: String, destinationPath: String, password: String?, promise: Promise) {
+        try {
+            val zipFile = ZipFile(zipFilePath)
+            if (zipFile.isEncrypted && password != null) {
+                zipFile.setPassword(password.toCharArray())
+            }
+            zipFile.extractAll(destinationPath)
+            promise.resolve(true)
+        } catch (e: ZipException) {
+            promise.reject("ERROR_UNZIPPING_FILE", "Failed to unzip the file", e)
+        }
+    }
+
+    @ReactMethod
+    fun createZipFile(destinationPath: String, sourcePath: String, password: String?, promise: Promise) {
+        try {
+            val zipFile = ZipFile(destinationPath)
+            val parameters = ZipParameters()
+            parameters.compressionLevel = CompressionLevel.NORMAL
+
+            if (password != null && password.isNotEmpty()) {
+                parameters.isEncryptFiles = true
+                parameters.encryptionMethod = EncryptionMethod.ZIP_STANDARD
+            }
+
+            val sourceFile = File(sourcePath)
+            if (sourceFile.isDirectory) {
+                zipFile.addFolder(sourceFile, parameters)
+            } else {
+                zipFile.addFile(sourceFile, parameters)
+            }
+
+            if (password != null && password.isNotEmpty()) {
+                zipFile.setPassword(password.toCharArray())
+            }
+
+            promise.resolve(true)
+        } catch (e: ZipException) {
+            promise.reject("ERROR_CREATING_ZIP", "Failed to create ZIP file", e)
+        }
+    }
 }

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,38 +1,51 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { StyleSheet, View, Text } from 'react-native';
-import {
-  listZipContents,
-  // streamFileFromZip,
-  // unzipFile,
-} from 'react-native-zip-stream';
+import { listZipContents } from 'react-native-zip-stream'; // Assuming the import is correct
 import RNFS from 'react-native-fs';
 
 export default function App() {
+  // Async function wrapped in useEffect
   const test = async () => {
-    const data = await listZipContents(
-      `${RNFS.DocumentDirectoryPath}/esmod-1.epub`
-    );
+    try {
+      // Check if the file exists before trying to list its contents
+      const filePath = `${RNFS.DocumentDirectoryPath}/`;
+      const fileExists = await RNFS.exists(filePath);
 
-    console.log(data);
+      if (!fileExists) {
+        console.log(`File not found at path: ${filePath}`);
+        return;
+      }
 
-    // const file = await streamFileFromZip(
-    //   `${RNFS.DocumentDirectoryPath}/esmod-1.epub`,
-    //   data[0]
-    // );
+      const data = await listZipContents(filePath);
 
-    // console.log(`${RNFS.DocumentDirectoryPath}/test`);
+      console.log('Contents of the ZIP file:', data);
 
-    // console.log(
-    //   await unzipFile(
-    //     `${RNFS.DocumentDirectoryPath}/esmod-1.epub`,
-    //     `${RNFS.DocumentDirectoryPath}/test`
-    //   )
-    // );
+      // Uncomment if you want to test other functionalities
+      // const file = await streamFileFromZip(
+      //   `${RNFS.DocumentDirectoryPath}/esmod-1.epub`,
+      //   data[0]
+      // );
+      // console.log('File from ZIP:', file);
+
+      // console.log(`${RNFS.DocumentDirectoryPath}/test`);
+      // const unzipResult = await unzipFile(
+      //   `${RNFS.DocumentDirectoryPath}/esmod-1.epub`,
+      //   `${RNFS.DocumentDirectoryPath}/test`
+      // );
+      // console.log('Unzipped successfully:', unzipResult);
+    } catch (error) {
+      console.error('An error occurred:', error);
+    }
   };
-  test();
+
+  // Use effect to run the test only once when the component mounts
+  useEffect(() => {
+    test(); // Call test only once on component mount
+  }, []); // Empty dependency array ensures this runs only once
+
   return (
     <View style={styles.container}>
-      <Text>TEst</Text>
+      <Text>Test</Text>
     </View>
   );
 }

--- a/ios/ZipStream.mm
+++ b/ios/ZipStream.mm
@@ -4,6 +4,7 @@
 
 // Exporting the listZipContents method
 RCT_EXTERN_METHOD(listZipContents:(NSString *)zipFilePath
+                 password:(NSString *)password
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject)
 

--- a/ios/ZipStream.mm
+++ b/ios/ZipStream.mm
@@ -11,12 +11,13 @@ RCT_EXTERN_METHOD(listZipContents:(NSString *)zipFilePath
 RCT_EXTERN_METHOD(streamFileFromZip:(NSString *)zipFilePath
                  entryName:(NSString *)entryName
                  type:(NSString *)type
+                 password:(NSString *)password
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject)
 
-// Exporting the unzipFile method
 RCT_EXTERN_METHOD(unzipFile:(NSString *)zipFilePath
                  destinationPath:(NSString *)destinationPath
+                 password:(NSString *)password
                  resolve:(RCTPromiseResolveBlock)resolve
                  reject:(RCTPromiseRejectBlock)reject)
 

--- a/ios/ZipStream.swift
+++ b/ios/ZipStream.swift
@@ -3,19 +3,31 @@ import ZipArchive
 @objc(ZipStream)
 class ZipStream: NSObject {
    @objc
-    func listZipContents(_ zipFilePath: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
-        do {
-            let zipFile = ZipArchive()
-            if !zipFile.unzipOpenFile(zipFilePath) {
-                throw NSError(domain: "com.zipstream", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to open ZIP file"])
-            }
-            let fileNames = zipFile.getZipFileContents()
-            zipFile.unzipCloseFile()
-            resolve(fileNames)
-        } catch let error {
-            reject("ERROR_LISTING_CONTENTS", "Failed to list contents of the ZIP file", error)
+func listZipContents(_ zipFilePath: String, password: String?, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    do {
+        let zipFile = ZipArchive()
+        
+        // Open the ZIP file, with or without a password
+        let success: Bool
+        if let password = password {
+            success = zipFile.unzipOpenFile(zipFilePath, password: password)
+        } else {
+            success = zipFile.unzipOpenFile(zipFilePath)
         }
+        
+        if !success {
+            throw NSError(domain: "com.zipstream", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to open ZIP file"])
+        }
+        
+        // Retrieve the list of file names from the ZIP file
+        let fileNames = zipFile.getZipFileContents()
+        zipFile.unzipCloseFile()
+        resolve(fileNames)
+        
+    } catch let error {
+        reject("ERROR_LISTING_CONTENTS", "Failed to list contents of the ZIP file", error)
     }
+}
 
    @objc
     func streamFileFromZip(_ zipFilePath: String, entryName: String, type: String, password: String?, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {

--- a/ios/ZipStream.swift
+++ b/ios/ZipStream.swift
@@ -17,22 +17,30 @@ class ZipStream: NSObject {
         }
     }
 
-    @objc
-    func streamFileFromZip(_ zipFilePath: String, entryName: String, type: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+   @objc
+    func streamFileFromZip(_ zipFilePath: String, entryName: String, type: String, password: String?, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         do {
             let zipFile = ZipArchive()
-            if !zipFile.unzipOpenFile(zipFilePath) {
-                throw NSError(domain: "com.zipstream", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to open ZIP file"])
+
+            let success: Bool
+            if let password = password {
+                success = zipFile.unzipOpenFile(zipFilePath, password: password)
+            } else {
+                success = zipFile.unzipOpenFile(zipFilePath)
             }
-            
+
+            if !success {
+                throw NSError(domain: "com.zipstream", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to open ZIP file with provided password"])
+            }
+
             guard let fileData = zipFile.unzipFileToMemory() else {
                 throw NSError(domain: "com.zipstream", code: 404, userInfo: [NSLocalizedDescriptionKey: "File not found in ZIP"])
             }
-            
+
             guard let fileContents = fileData[entryName] as? Data else {
                 throw NSError(domain: "com.zipstream", code: 404, userInfo: [NSLocalizedDescriptionKey: "File not found in ZIP"])
             }
-            
+
             var result: Any?
             if type == "base64" {
                 result = fileContents.base64EncodedString()
@@ -47,7 +55,7 @@ class ZipStream: NSObject {
             } else {
                 throw NSError(domain: "com.zipstream", code: 400, userInfo: [NSLocalizedDescriptionKey: "Invalid type specified"])
             }
-            
+
             zipFile.unzipCloseFile()
             resolve(result)
         } catch let error {
@@ -55,21 +63,37 @@ class ZipStream: NSObject {
         }
     }
 
+
     @objc
-    func unzipFile(_ zipFilePath: String, destinationPath: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    func unzipFile(_ zipFilePath: String, destinationPath: String, password: String?, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         let zipFile = ZipArchive()
-        
-        if zipFile.unzipOpenFile(zipFilePath) {
-            let success = zipFile.unzipFile(to: destinationPath, overWrite: true)
-            zipFile.unzipCloseFile()
-            
-            if success {
-                resolve(true)
+
+        if let password = password {
+            if zipFile.unzipOpenFile(zipFilePath, password: password) {
+                let success = zipFile.unzipFile(to: destinationPath, overWrite: true)
+                zipFile.unzipCloseFile()
+
+                if success {
+                    resolve(true)
+                } else {
+                    reject("ERROR_UNZIPPING_FILE", "Failed to unzip the file", nil)
+                }
             } else {
-                reject("ERROR_UNZIPPING_FILE", "Failed to unzip the file", nil)
+                reject("ERROR_OPENING_ZIP", "Failed to open ZIP file with password", nil)
             }
         } else {
-            reject("ERROR_OPENING_ZIP", "Failed to open ZIP file", nil)
+            if zipFile.unzipOpenFile(zipFilePath) {
+                let success = zipFile.unzipFile(to: destinationPath, overWrite: true)
+                zipFile.unzipCloseFile()
+
+                if success {
+                    resolve(true)
+                } else {
+                    reject("ERROR_UNZIPPING_FILE", "Failed to unzip the file", nil)
+                }
+            } else {
+                reject("ERROR_OPENING_ZIP", "Failed to open ZIP file", nil)
+            }
         }
     }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -52,7 +52,8 @@ export const listZipContents = async (
 export const streamFileFromZip = async (
   zipFilePath: string,
   entryName: string,
-  type: 'base64' | 'arraybuffer' | 'string' = 'base64'
+  type: 'base64' | 'arraybuffer' | 'string' = 'base64',
+  password?: string
 ): Promise<string | ArrayBuffer | Uint8Array> => {
   validateStringParam(zipFilePath, 'zipFilePath');
   validateStringParam(entryName, 'entryName');
@@ -61,7 +62,8 @@ export const streamFileFromZip = async (
     return await ZipStreamModule.streamFileFromZip(
       zipFilePath,
       entryName,
-      type
+      type,
+      password || null
     );
   } catch (error) {
     log('Error streaming file from ZIP', error);
@@ -71,13 +73,18 @@ export const streamFileFromZip = async (
 
 export const unzipFile = async (
   zipFilePath: string,
-  destinationPath: string
+  destinationPath: string,
+  password?: string
 ): Promise<boolean> => {
   validateStringParam(zipFilePath, 'zipFilePath');
   validateStringParam(destinationPath, 'destinationPath');
 
   try {
-    return await ZipStreamModule.unzipFile(zipFilePath, destinationPath);
+    return await ZipStreamModule.unzipFile(
+      zipFilePath,
+      destinationPath,
+      password || null
+    );
   } catch (error) {
     log('Error unzipping file', error);
     throw error;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -37,12 +37,13 @@ const log = (message: string, error?: any) => {
 };
 
 export const listZipContents = async (
-  zipFilePath: string
+  zipFilePath: string,
+  password?: string
 ): Promise<string[]> => {
   validateStringParam(zipFilePath, 'zipFilePath');
 
   try {
-    return await ZipStreamModule.listZipContents(zipFilePath);
+    return await ZipStreamModule.listZipContents(zipFilePath, password || null);
   } catch (error) {
     log('Error listing ZIP contents', error);
     throw error;
@@ -93,13 +94,18 @@ export const unzipFile = async (
 
 export const createZipFile = async (
   destinationPath: string,
-  sourcePath: string
+  sourcePath: string,
+  password?: string
 ): Promise<boolean> => {
   validateStringParam(destinationPath, 'destinationPath');
   validateStringParam(sourcePath, 'sourcePath');
 
   try {
-    return await ZipStreamModule.createZipFile(destinationPath, sourcePath);
+    return await ZipStreamModule.createZipFile(
+      destinationPath,
+      sourcePath,
+      password || null
+    );
   } catch (error) {
     log('Error creating ZIP file', error);
     throw error;


### PR DESCRIPTION
This pull request introduces the ability to handle password-protected ZIP files in the `streamFileFromZip` and `unzipFile` methods for both iOS and Android platforms.

### Key Updates:
- **Password Handling in `unzipFile`:** You can now provide a password when extracting ZIP files to a destination folder.
- **Password Handling in `streamFileFromZip`:** Streams files from a password-protected ZIP archive by supplying a password. Supports returning file data in `base64`, `arraybuffer`, or `string` format.

### Affected Methods:
- **`unzipFile`**: Now supports password-protected ZIP extraction.
- **`streamFileFromZip`**: Now supports streaming files from password-protected ZIPs.

### Notes:
- The update ensures compatibility across both iOS (Swift) and Android (Kotlin) platforms, with the use of `Zip4j` on Android for handling encrypted ZIP files.

